### PR TITLE
Implement logout and enforce JWT secret

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,8 +1,12 @@
 import User from '../models/User.js';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { blacklistToken } from '../utils/tokenBlacklist.js';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'chavepadrao';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
 
 export const register = async (req, res) => {
   const { email, senha } = req.body;
@@ -67,4 +71,14 @@ export const updatePerfil = async (req, res) => {
   } catch (error) {
     res.status(500).json({ message: 'Erro ao atualizar perfil.', error });
   }
+};
+
+export const logout = (req, res) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader)
+    return res.status(400).json({ message: 'Token não fornecido.' });
+
+  const [, token] = authHeader.split(' ');
+  blacklistToken(token);
+  res.json({ message: 'Logout realizado com sucesso.' });
 };

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,6 +1,10 @@
 import jwt from 'jsonwebtoken';
+import { isTokenBlacklisted } from '../utils/tokenBlacklist.js';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'chavepadrao';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
 
 const authMiddleware = (req, res, next) => {
   const authHeader = req.headers.authorization;
@@ -9,6 +13,9 @@ const authMiddleware = (req, res, next) => {
     return res.status(401).json({ message: 'Token não fornecido.' });
 
   const [, token] = authHeader.split(' ');
+
+  if (isTokenBlacklisted(token))
+    return res.status(401).json({ message: 'Token inválido.' });
 
   try {
     const decoded = jwt.verify(token, JWT_SECRET);

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -4,6 +4,7 @@ import {
   login,
   getPerfil,
   updatePerfil,
+  logout,
 } from '../controllers/authController.js';
 import authMiddleware from '../middleware/authMiddleware.js';
 
@@ -11,6 +12,7 @@ const router = express.Router();
 
 router.post('/register', register);
 router.post('/login', login);
+router.post('/logout', authMiddleware, logout);
 router.get('/perfil', authMiddleware, getPerfil);
 router.put('/perfil', authMiddleware, updatePerfil);
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,9 @@ import dotenv from 'dotenv';
 import authRoutes from './routes/auth.js';
 
 dotenv.config();
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
 
 const app = express();
 const PORT = process.env.PORT || 3000;

--- a/backend/utils/tokenBlacklist.js
+++ b/backend/utils/tokenBlacklist.js
@@ -1,0 +1,7 @@
+const blacklist = new Set();
+
+export const blacklistToken = (token) => {
+  blacklist.add(token);
+};
+
+export const isTokenBlacklisted = (token) => blacklist.has(token);


### PR DESCRIPTION
## Summary
- ensure `JWT_SECRET` is present before starting server
- validate presence of `JWT_SECRET` in auth modules
- keep a simple in-memory JWT blacklist
- add `/logout` endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68437350c768832387fa5f8532cd4448