### PR TITLE
Implement JWT auth & cleanup

### DIFF
--- a/frontend/src/Routes.jsx
+++ b/frontend/src/Routes.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ModernLayout from "./components/ModernLayout";
+import ProtectedRoute from "./components/ProtectedRoute";
 import Cardapio from "./pages/Cardapio"; 
 import Comanda from "./pages/Comanda";
 import FinalizarCompra from "./pages/FinalizarCompra";
@@ -18,10 +19,10 @@ export default function AppRoutes() {
         <Route element={<ModernLayout />}>
           <Route path="/" element={<Cardapio />} />
           <Route path="/comanda" element={<Comanda />} />
-          <Route path="/finalizar" element={<FinalizarCompra />} />
+          <Route path="/finalizar" element={<ProtectedRoute element={<FinalizarCompra />} />} />
           <Route path="/fila-digital" element={<FilaDigital />} />
           <Route path="/chat" element={<Chat />} />
-          <Route path="/perfil" element={<Perfil />} />
+          <Route path="/perfil" element={<ProtectedRoute element={<Perfil />} />} />
           <Route path="/escanear" element={<Escanear />} />
           <Route path="/login" element={<LoginCadastro />} /> {/* MOVIDO PARA DENTRO */}
         </Route>

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,16 +1,32 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
-import { getAuth } from 'firebase/auth';
 
 const ProtectedRoute = ({ element }) => {
-  const auth = getAuth();
-  const user = auth.currentUser; // Verifica se o usuário está autenticado
-  
-  if (!user) {
-    return <Navigate to="/login" replace />; // Redireciona para login se não estiver autenticado
-  }
+  const [authorized, setAuthorized] = useState(null);
 
-  return element; // Se o usuário estiver autenticado, renderiza o componente protegido
+  useEffect(() => {
+    const verify = async () => {
+      const token = localStorage.getItem('token');
+      if (!token) {
+        setAuthorized(false);
+        return;
+      }
+      try {
+        const res = await fetch(`${import.meta.env.VITE_API_URL}/perfil`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setAuthorized(res.ok);
+      } catch {
+        setAuthorized(false);
+      }
+    };
+
+    verify();
+  }, []);
+
+  if (authorized === null) return null;
+
+  return authorized ? element : <Navigate to="/login" replace />;
 };
 
 export default ProtectedRoute;

--- a/frontend/src/pages/FinalizarCompra.jsx
+++ b/frontend/src/pages/FinalizarCompra.jsx
@@ -11,8 +11,11 @@ const FinalizarCompra = () => {
   useEffect(() => {
     const verificarLogin = async () => {
       try {
+        const token = localStorage.getItem('token');
         const res = await fetch(`${import.meta.env.VITE_API_URL}/perfil`, {
-          credentials: 'include',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
         });
 
         if (!res.ok) {

--- a/frontend/src/pages/LoginCadastro.jsx
+++ b/frontend/src/pages/LoginCadastro.jsx
@@ -29,11 +29,12 @@ const LoginCadastro = () => {
         headers: {
           'Content-Type': 'application/json',
         },
-        credentials: 'include',
         body: JSON.stringify({ email, senha }),
       });
 
       if (response.ok) {
+        const { token } = await response.json();
+        localStorage.setItem('token', token);
         navigate('/perfil');
       } else {
         const { message } = await response.json();

--- a/frontend/src/pages/Perfil.jsx
+++ b/frontend/src/pages/Perfil.jsx
@@ -14,8 +14,11 @@ const Perfil = () => {
   useEffect(() => {
     const fetchUser = async () => {
       try {
+        const token = localStorage.getItem('token');
         const res = await fetch(`${import.meta.env.VITE_API_URL}/perfil`, {
-          credentials: 'include',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
         });
 
         if (res.ok) {
@@ -44,13 +47,14 @@ const Perfil = () => {
     }
 
     try {
+      const token = localStorage.getItem('token');
       const res = await fetch(`${import.meta.env.VITE_API_URL}/perfil`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({ nome, telefone }),
-        credentials: 'include',
       });
 
       if (res.ok) {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,37 +1,21 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-    content: [
-      './index.html',
-      './src/**/*.{js,ts,jsx,tsx}',
-    ],
-    theme: {
-      extend: {},
-    },
-    plugins: [],
-  };
-
-  /* No arquivo Tailwind CSS config */
-theme: {
-  extend: {
-    colors: {
-      primary: '#3b82f6',
-      secondary: '#9333ea',
-      accent: '#10b981',
-      neutral: '#1f2937',
-    },
-    fontFamily: {
-      sans: ['Inter', 'Arial', 'sans-serif'],
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#3b82f6',
+        secondary: '#9333ea',
+        accent: '#10b981',
+        neutral: '#1f2937',
+      },
+      fontFamily: {
+        sans: ['Inter', 'Arial', 'sans-serif'],
+      },
     },
   },
-}
-
-@keyframes fadeInOut {
-  0% { opacity: 0; transform: translateY(20px); }
-  10% { opacity: 1; transform: translateY(0); }
-  90% { opacity: 1; transform: translateY(0); }
-  100% { opacity: 0; transform: translateY(20px); }
-}
-
-.animate-fade-in-out {
-  animation: fadeInOut 2.5s ease-in-out forwards;
-}
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- store JWT token in LoginCadastro
- send Authorization header in Perfil and FinalizarCompra
- add ProtectedRoute that validates token using backend
- protect routes that require authentication
- fix tailwind config and lint errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684373486c8483239804a7863d01c207